### PR TITLE
Rename variable w to w_j in bhmbasket::setPriorParametersExNex in tes…

### DIFF
--- a/tests/testthat/test-get_details.R
+++ b/tests/testthat/test-get_details.R
@@ -106,7 +106,7 @@ test_that("get_details works for bhm", {
     alpha_level = 0.05
   )
 
-  # Results are equal with get_details and bhmbasket
+  # Results are equal with get_details and 
   expect_equal(res1$Rejection_Probabilities, unname(unlist(res2))[-1])
   expect_equal(res1$Mean, unname(estim$berry$scenario_1[, 1]))
   expect_equal(res1$MSE, unname(estim$berry$scenario_1[, 7]))
@@ -190,7 +190,7 @@ test_that("get_details works for exnex", {
       tau_scale = 0.75,
       mu_j = rep(bhmbasket:::logit(0.15), 3),
       tau_j = rep(100, 3),
-      w = 0.5
+      w_j = 0.5
     )
   ))
 


### PR DESCRIPTION
…t-get_details.R

The weight argument of bhmbasket::setPriorParametersExNex is called w_j. This typo results in an error in the latest version of bhmbasket, because bhmbasket::setPriorParametersExNex now has an additional argument starting with the letter w.

See also:

Backtrace:
        ▆
     1. ├─basksim::adjust_lambda(...) at test-adjust_lambda.R:63:3
     2. └─basksim:::adjust_lambda.exnex(...)
     3.   └─base::do.call(...)
    ── Error ('test-get_details.R:113:3'): get_details works for exnex ─────────────
    Error in `bhmbasket::setPriorParametersExNex(mu_mean = bhmbasket:::logit(0.15), mu_sd = 100, tau_scale = 0.75, mu_j = rep(bhmbasket:::logit(0.15), 3), tau_j = rep(100, 3), w = 0.5)`: **_argument 6 matches multiple formal arguments_**
    Backtrace:
        ▆
     1. ├─base::suppressMessages(...) at test-get_details.R:113:3
     2. │ └─base::withCallingHandlers(...)
     3. └─bhmbasket::performAnalyses(...)